### PR TITLE
misc: show friendly error message when native function not found

### DIFF
--- a/j17/src/fr/hammons/slinc/modules/FSetModule17.scala
+++ b/j17/src/fr/hammons/slinc/modules/FSetModule17.scala
@@ -9,6 +9,7 @@ import fr.hammons.slinc.Variadic
 import fr.hammons.slinc.FunctionContext
 import fr.hammons.slinc.DescriptorOf
 import fr.hammons.slinc.fset.Dependency
+import java.util.NoSuchElementException
 
 given fsetModule17: FSetModule with
   val runtimeVersion = 17
@@ -29,7 +30,11 @@ given fsetModule17: FSetModule with
           val functionInformation = FunctionContext(cfd)
           val addr = defaultLookup(functionInformation.name)
             .orElse(loaderLookup(functionInformation.name))
-            .get
+            .getOrElse(
+              throw new NoSuchElementException(
+                s"unable to find native function: ${functionInformation.name}"
+              )
+            )
           val mh: MethodHandler = MethodHandler((v: Seq[Variadic]) =>
             getDowncall(cfd, v).bindTo(addr).nn
           )

--- a/j19/src/fr/hammons/slinc/modules/FSetModule19.scala
+++ b/j19/src/fr/hammons/slinc/modules/FSetModule19.scala
@@ -7,6 +7,8 @@ import fr.hammons.slinc.fset.FSetBacking
 
 import fr.hammons.slinc.FunctionContext
 import fr.hammons.slinc.fset.Dependency
+
+import java.util.NoSuchElementException
 given fsetModule19: FSetModule with
   override val runtimeVersion: Int = 19
 
@@ -26,7 +28,11 @@ given fsetModule19: FSetModule with
           val runtimeInformation = FunctionContext(cfd)
           val addr = defaultLookup(runtimeInformation.name)
             .orElse(loaderLookup(runtimeInformation.name))
-            .get
+            .getOrElse(
+              throw new NoSuchElementException(
+                s"unable to find native function: ${runtimeInformation.name}"
+              )
+            )
           val mh: MethodHandler = MethodHandler((v: Seq[Variadic]) =>
             getDowncall(cfd, v).bindTo(addr).nn
           )


### PR DESCRIPTION
After this commit, SlinC shows what function cannot be found.

Before this commit, when SlinC was unable to find native function of given name, it raised `java.util.NoSuchElementException: None.get`.
```
Exception in thread "main" java.util.NoSuchElementException: None.get
        at scala.None$.get(Option.scala:627)
        at scala.None$.get(Option.scala:626)
        at fr.hammons.slinc.modules.FSetModule17$package$fsetModule17$.$anonfun$1(FSetModule17.scala:31)
        at scala.collection.immutable.List.map(List.scala:246)
```