### PR TITLE
feat: refine library resolution procedure

### DIFF
--- a/core/src/fr/hammons/slinc/annotations/NeedsFile.scala
+++ b/core/src/fr/hammons/slinc/annotations/NeedsFile.scala
@@ -13,7 +13,8 @@ final case class NeedsFile(val path: String)
     val fileName = filePath.getFileName().toString()
     Dependency.FilePath(
       filePath,
-      fileName.endsWith(".so") || fileName.endsWith(".dll")
+      fileName.endsWith(".so") || fileName.endsWith(".dylib") || fileName
+        .endsWith(".dll")
     )
 
 object NeedsFile:

--- a/core/src/fr/hammons/slinc/annotations/NeedsResource.scala
+++ b/core/src/fr/hammons/slinc/annotations/NeedsResource.scala
@@ -13,7 +13,7 @@ final case class NeedsResource(val resourcePath: String)
     case path =>
       Dependency.LibraryResource(
         path,
-        path.endsWith(".so") || path.endsWith(".dll")
+        path.endsWith(".so") || path.endsWith(".dylib") || path.endsWith(".dll")
       )
 
 object NeedsResource:

--- a/core/src/fr/hammons/slinc/modules/LinkageTools.scala
+++ b/core/src/fr/hammons/slinc/modules/LinkageTools.scala
@@ -140,12 +140,11 @@ object LinkageTools:
       suffixCandidates: Seq[String],
       archMarks: Set[String]
   ): Seq[String] =
-    val withoutArchMarks = suffixCandidates.map(sfx => s"$location$sfx")
-    if archMarks.isEmpty then withoutArchMarks
+    if archMarks.isEmpty then Seq.empty
     else
       suffixCandidates.flatMap { suffix =>
         archMarks.map(archMark => s"${location}_$archMark$suffix")
-      } ++ withoutArchMarks
+      }
 
   def compileCachedCCode(cachedFile: CacheFile): Path =
     val libLocation = cachedFile.cachePath.toString() match


### PR DESCRIPTION
rel https://github.com/markehammons/slinc/discussions/153#discussion-5087195
- ~~use `libname.so` instead of `libname_.so` when potential arch mark is unknown~~
- lookup `.dylib` on OSX first and then fallback to `.so` file
- include `.dylib` suffix as absolute paths